### PR TITLE
AC-270952: Added missing using directive in code snippet

### DIFF
--- a/UnitTesting/T280/CodeSnippets/Activity2.4/InventoryItemMaintTests.cs
+++ b/UnitTesting/T280/CodeSnippets/Activity2.4/InventoryItemMaintTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using PX.Data;
 using PX.Tests.Unit;
 using PX.Objects.IN;
+using PhoneRepairShop;
 
 namespace PhoneRepairShop_Code.Tests
 {


### PR DESCRIPTION
Added missing using directive which was not allowing the code to compile for InventoryItemMaintTests class. This is the only code change in code snippets for T280 course update.