### PR TITLE
Update topics and snippets related to the new targeted overrides of the PXGraph Persist method

### DIFF
--- a/WorkflowDevelopment/T270/CodeSnippets/Activity2.1/Step6/ARReleaseProcess.cs
+++ b/WorkflowDevelopment/T270/CodeSnippets/Activity2.1/Step6/ARReleaseProcess.cs
@@ -8,18 +8,14 @@ namespace PhoneRepairShop
     // Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
     public class ARReleaseProcess_Extension : PXGraphExtension<ARReleaseProcess>
     {
-        public SelectFrom<RSSVWorkOrder>.View UpdWorkOrder;
-
-        [PXOverride]
-        public virtual void Persist(Action baseMethod)
-        {
-            using (PXTransactionScope ts = new PXTransactionScope())
-            {
-                baseMethod();
-                UpdWorkOrder.Cache.Persist(PXDBOperation.Update);
-                ts.Complete(Base);
-            }
-            UpdWorkOrder.Cache.Persisted(false);
-        }
+		public SelectFrom<RSSVWorkOrder>.View UpdWorkOrder;
+		
+		[PXOverride]
+		public void PerformPersist(PXGraph.IPersistPerformer persister,
+		            Action<PXGraph.IPersistPerformer> base_PerformPersist)
+		{
+			base_PerformPersist(persister);
+			persister.Update<RSSVWorkOrder>();
+		}
     }
 }

--- a/WorkflowDevelopment/T270/CodeSnippets/Activity2.2/Step5/ARReleaseProcess.cs
+++ b/WorkflowDevelopment/T270/CodeSnippets/Activity2.2/Step5/ARReleaseProcess.cs
@@ -8,18 +8,14 @@ namespace PhoneRepairShop
     // Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
     public class ARReleaseProcess_Extension : PXGraphExtension<ARReleaseProcess>
     {
-        public SelectFrom<RSSVWorkOrder>.View UpdWorkOrder;
+		public SelectFrom<RSSVWorkOrder>.View UpdWorkOrder;
 
         [PXOverride]
-        public virtual void Persist(Action baseMethod)
+        public void PerformPersist(PXGraph.IPersistPerformer persister,
+                    Action<PXGraph.IPersistPerformer> base_PerformPersist)
         {
-            using (PXTransactionScope ts = new PXTransactionScope())
-            {
-                baseMethod();
-                UpdWorkOrder.Cache.Persist(PXDBOperation.Update);
-                ts.Complete(Base);
-            }
-            UpdWorkOrder.Cache.Persisted(false);
+            base_PerformPersist(persister);
+            persister.Update<RSSVWorkOrder>();
         }
 
         ////////// The added code


### PR DESCRIPTION
Updated the code snippets (and the related topics in help) in workflow API guide related to overriding the Persist method. According to SME, the best practice is to override one of the new targeted overrides of the Persist method. In this case this is the PerformPersist method.

I have tested the course using the new snippets and got the same results as with the previous override of the Persist method.