### PR TITLE
EDU-7706: Added back the manually created files PerTenantFiles

### DIFF
--- a/Customization/T220/PhoneRepairShop/_project/screens_RS_RS101000_RS101000_html.xml
+++ b/Customization/T220/PhoneRepairShop/_project/screens_RS_RS101000_RS101000_html.xml
@@ -1,0 +1,1 @@
+<PerTenantFile AppRelativePath="screens\RS\RS101000\RS101000.html" ScreenId="RS101000" FileID="496a29f6-aad7-4118-a59d-85921dab5415" />

--- a/Customization/T220/PhoneRepairShop/_project/screens_RS_RS101000_RS101000_ts.xml
+++ b/Customization/T220/PhoneRepairShop/_project/screens_RS_RS101000_RS101000_ts.xml
@@ -1,0 +1,1 @@
+<PerTenantFile AppRelativePath="screens\RS\RS101000\RS101000.ts" ScreenId="RS101000" FileID="f5ccd62b-5fad-487a-a70e-693521190177" />

--- a/Customization/T220/PhoneRepairShop/_project/screens_RS_RS301000_RS301000_html.xml
+++ b/Customization/T220/PhoneRepairShop/_project/screens_RS_RS301000_RS301000_html.xml
@@ -1,0 +1,1 @@
+<PerTenantFile AppRelativePath="screens\RS\RS301000\RS301000.html" ScreenId="RS301000" FileID="11e14407-a775-4cfa-a239-bdd89568fe9c" />

--- a/Customization/T220/PhoneRepairShop/_project/screens_RS_RS301000_RS301000_ts.xml
+++ b/Customization/T220/PhoneRepairShop/_project/screens_RS_RS301000_RS301000_ts.xml
@@ -1,0 +1,1 @@
+<PerTenantFile AppRelativePath="screens\RS\RS301000\RS301000.ts" ScreenId="RS301000" FileID="91af9b66-1157-4a59-bd8c-11345fe593d8" />


### PR DESCRIPTION
Added back the manually created files PerTenantFiles that were not included in the exported project. They seem to be necessary for successfully publishing the customization project on another instance.