### PR TITLE
EDU-9636: Added the autogenerated Master and Details view to RSSVRepairPriceMaint graph

### DIFF
--- a/Customization/T210/CodeSnippets/Step2.1.1/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step2.1.1/RSSVRepairPriceMaint.cs
@@ -9,6 +9,21 @@ namespace PhoneRepairShop
     {
         #region Data Views
         public SelectFrom<RSSVRepairPrice>.View RepairPrices = null!;
+    
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
         #endregion
     }
 }

--- a/Customization/T210/CodeSnippets/Step2.1.2/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step2.1.2/RSSVRepairPriceMaint.cs
@@ -18,6 +18,22 @@ namespace PhoneRepairShop
                 IsEqual<RSSVRepairPrice.deviceID.FromCurrent>>>.View
             RepairItems = null!;
         ////////// The end of added code
+        
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
     }
 }

--- a/Customization/T210/CodeSnippets/Step2.2.2/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step2.2.2/RSSVRepairPriceMaint.cs
@@ -17,6 +17,22 @@ namespace PhoneRepairShop
             And<RSSVRepairItem.deviceID.
                 IsEqual<RSSVRepairPrice.deviceID.FromCurrent>>>.View
             RepairItems = null!;
+
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
 
         ////////// The added code
@@ -36,7 +52,8 @@ namespace PhoneRepairShop
                     as InventoryItem;
                 //Copy the repair item type from the stock item to the row.
                 var itemExt = item?.GetExtension<InventoryItemExt>();
-                if (itemExt != null) e.Cache.SetValueExt<RSSVRepairItem.repairItemType>(
+                if (itemExt != null)
+                   e.Cache.SetValueExt<RSSVRepairItem.repairItemType>(
                     row, itemExt.UsrRepairItemType);
             }
             //Trigger the FieldDefaulting event handler for basePrice.

--- a/Customization/T210/CodeSnippets/Step2.2.3/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step2.2.3/RSSVRepairPriceMaint.cs
@@ -20,6 +20,22 @@ namespace PhoneRepairShop
             And<RSSVRepairItem.deviceID.
                 IsEqual<RSSVRepairPrice.deviceID.FromCurrent>>>.View
             RepairItems = null!;
+
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Customization/T210/CodeSnippets/Step2.2.4/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step2.2.4/RSSVRepairPriceMaint.cs
@@ -18,6 +18,22 @@ namespace PhoneRepairShop
             And<RSSVRepairItem.deviceID.
                 IsEqual<RSSVRepairPrice.deviceID.FromCurrent>>>.View
             RepairItems = null!;
+  
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Customization/T210/CodeSnippets/Step4.1.1/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step4.1.1/RSSVRepairPriceMaint.cs
@@ -26,6 +26,22 @@ namespace PhoneRepairShop
                 IsEqual<RSSVRepairPrice.serviceID.FromCurrent>>>.View
             Labor = null!;
         ////////// The end of added code
+        
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
         
         #region Event Handlers

--- a/Customization/T210/CodeSnippets/Step4.2.1/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step4.2.1/RSSVRepairPriceMaint.cs
@@ -34,6 +34,22 @@ namespace PhoneRepairShop
             OrderBy<RSSVWarranty.defaultWarranty.Desc>.View
             Warranty = null!;
         ////////// The end of added code
+
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Customization/T210/CodeSnippets/Step4.2.2/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step4.2.2/RSSVRepairPriceMaint.cs
@@ -42,6 +42,22 @@ namespace PhoneRepairShop
             Where<ContractTemplate.contractCD.IsEqual<defaultWarranty>>.
             View DefaultWarranty = null!;
         ////////// The end of added code
+
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
 
         #region Event Handlers

--- a/Customization/T210/CodeSnippets/Step4.2.3/RSSVRepairPriceMaint.cs
+++ b/Customization/T210/CodeSnippets/Step4.2.3/RSSVRepairPriceMaint.cs
@@ -39,6 +39,22 @@ namespace PhoneRepairShop
         public SelectFrom<ContractTemplate>.
             Where<ContractTemplate.contractCD.IsEqual<defaultWarranty>>.
             View DefaultWarranty = null!;
+
+        public PXFilter<MasterTable> MasterView;
+        public PXFilter<DetailsTable> DetailsView;
+
+        [Serializable]
+        public class MasterTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
+        [Serializable]
+        public class DetailsTable : PXBqlTable, IBqlTable
+        {
+
+        }
+
         #endregion
 
         #region Event Handlers


### PR DESCRIPTION
Elena complains that without them the intermittent error about Master View not existing occurs when opening the RS203000 form. 